### PR TITLE
Add Vitest setup with a basic Navbar test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.0.3",
@@ -40,6 +41,10 @@
     "autoprefixer": "^10.4.16",
     "eslint": "^8.57.1",
     "eslint-config-react-app": "^7.0.1",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "vitest": "^0.34.6",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.3",
     "terser": "^5.39.0",

--- a/src/components/__tests__/Navbar.test.jsx
+++ b/src/components/__tests__/Navbar.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Navbar from '../Navbar';
+
+describe('Navbar', () => {
+  it('renders site title', () => {
+    render(<Navbar />);
+    expect(screen.getByText('Mi Portfolio')).toBeInTheDocument();
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -191,10 +191,15 @@ export default defineConfig({
 		},
 		allowedHosts: true,
 	},
-	resolve: {
-		extensions: ['.jsx', '.js', '.tsx', '.ts', '.json', ],
-		alias: {
-			'@': path.resolve(__dirname, './src'),
-		},
-	},
+       resolve: {
+                extensions: ['.jsx', '.js', '.tsx', '.ts', '.json', ],
+                alias: {
+                        '@': path.resolve(__dirname, './src'),
+                },
+        },
+        test: {
+                globals: true,
+                environment: 'jsdom',
+                setupFiles: './vitest.setup.js',
+        },
 });

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add `test` script and testing dev dependencies
- configure Vitest in `vite.config.js`
- create Vitest setup file for jest-dom
- add sample Navbar test

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3f521260832d966711d54d65f0b4