### PR TITLE
Agregar .gitignore en backend

### DIFF
--- a/galactic-backend/.gitignore
+++ b/galactic-backend/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+uploads/
+.DS_Store


### PR DESCRIPTION
## Resumen
- agregar `.gitignore` dentro de `galactic-backend/` para ignorar `node_modules/`, `.env`, `uploads/` y `.DS_Store`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6859d2bdef30832dae8aa4dc3316bd4e